### PR TITLE
Add API to render a PDF to a data buffer

### DIFF
--- a/src/api/pdfrenderer.cpp
+++ b/src/api/pdfrenderer.cpp
@@ -178,11 +178,20 @@ static const int kMaxBytesPerCodepoint = 20;
  **********************************************************************/
 TessPDFRenderer::TessPDFRenderer(const char *outputbase, const char *datadir,
                                  bool textonly)
-    : TessResultRenderer(outputbase, "pdf"),
-      datadir_(datadir) {
-  obj_  = 0;
-  textonly_ = textonly;
-  offsets_.push_back(0);
+    : TessResultRenderer(outputbase, "pdf"), datadir_(datadir) {
+        obj_  = 0;
+        textonly_ = textonly;
+        offsets_.push_back(0);
+        writeToBuffer_ = false;
+}
+
+TessPDFRenderer::TessPDFRenderer(const char* datadir, bool textonly)
+: TessResultRenderer("pdf"), datadir_(datadir) {
+    obj_  = 0;
+    textonly_ = textonly;
+    offsets_.push_back(0);
+    writeToBuffer_ = true;
+    outputBuffer_ = std::vector<char>();
 }
 
 void TessPDFRenderer::AppendPDFObjectDIY(size_t objectsize) {

--- a/src/api/renderer.cpp
+++ b/src/api/renderer.cpp
@@ -36,7 +36,8 @@ TessResultRenderer::TessResultRenderer(const char *outputbase,
       title_(""), imagenum_(-1),
       fout_(stdout),
       next_(nullptr),
-      happy_(true) {
+      happy_(true),
+      writeToBuffer_(false) {
   if (strcmp(outputbase, "-") && strcmp(outputbase, "stdout")) {
     STRING outfile = STRING(outputbase) + STRING(".") + STRING(file_extension_);
     fout_ = fopen(outfile.string(), "wb");
@@ -45,6 +46,15 @@ TessResultRenderer::TessResultRenderer(const char *outputbase,
     }
   }
 }
+
+TessResultRenderer::TessResultRenderer(const char* extension)
+: file_extension_(extension),
+  title_(""), imagenum_(-1),
+  fout_(stdout),
+  next_(nullptr),
+  happy_(true),
+  writeToBuffer_(true)
+{ }
 
 TessResultRenderer::~TessResultRenderer() {
   if (fout_ != nullptr) {
@@ -104,7 +114,14 @@ void TessResultRenderer::AppendString(const char* s) {
 }
 
 void TessResultRenderer::AppendData(const char* s, int len) {
-  if (!tesseract::Serialize(fout_, s, len)) happy_ = false;
+    if (writeToBuffer_) {
+        outputBuffer_.reserve(outputBuffer_.size() + len);
+        for (int i = 0; i < len; i++) {
+            outputBuffer_.push_back(s[i]);
+        }
+    } else {
+        if (!tesseract::Serialize(fout_, s, len)) happy_ = false;
+    }
 }
 
 bool TessResultRenderer::BeginDocumentHandler() {

--- a/src/api/renderer.cpp
+++ b/src/api/renderer.cpp
@@ -116,9 +116,7 @@ void TessResultRenderer::AppendString(const char* s) {
 void TessResultRenderer::AppendData(const char* s, int len) {
     if (writeToBuffer_) {
         outputBuffer_.reserve(outputBuffer_.size() + len);
-        for (int i = 0; i < len; i++) {
-            outputBuffer_.push_back(s[i]);
-        }
+        outputBuffer_.insert(outputBuffer_.end(), s, s + len);
     } else {
         if (!tesseract::Serialize(fout_, s, len)) happy_ = false;
     }

--- a/src/api/renderer.h
+++ b/src/api/renderer.h
@@ -145,6 +145,9 @@ class TESS_API TessResultRenderer {
   // This method will grow the output buffer if needed.
   void AppendData(const char* s, int len);
 
+  bool writeToBuffer_;
+  std::vector<char> outputBuffer_;
+
  private:
   const char* file_extension_;  // standard extension for generated output
   STRING title_;                // title of document being renderered
@@ -153,8 +156,6 @@ class TESS_API TessResultRenderer {
   FILE* fout_;                // output file pointer
   TessResultRenderer* next_;  // Can link multiple renderers together
   bool happy_;                // I get grumpy when the disk fills up, etc.
-  bool writeToBuffer_;
-  std::vector<char> outputBuffer_;
 };
 
 /**
@@ -227,9 +228,6 @@ class TESS_API TessPDFRenderer : public TessResultRenderer {
 
  TessPDFRenderer(const char* datadir, bool textonly = false);
     
-    
- std::vector<char> getOutputBuffer();
-    
  protected:
   bool BeginDocumentHandler() override;
   bool AddImageHandler(TessBaseAPI* api) override;
@@ -245,8 +243,6 @@ class TESS_API TessPDFRenderer : public TessResultRenderer {
   GenericVector<long int> offsets_;  // offset of every PDF object in bytes
   GenericVector<long int> pages_;    // object number for every /Page object
   std::string datadir_;              // where to find the custom font
-  std::vector<char> outputBuffer_;
-  bool writeToBuffer_;
   bool textonly_;                    // skip images if set
   // Bookkeeping only. DIY = Do It Yourself.
   void AppendPDFObjectDIY(size_t objectsize);

--- a/src/api/renderer.h
+++ b/src/api/renderer.h
@@ -92,6 +92,10 @@ class TESS_API TessResultRenderer {
   bool happy() {
     return happy_;
   }
+    
+  std::vector<char> outputBuffer() {
+    return outputBuffer_;
+  }
 
   /**
    * Returns the index of the last image given to AddImage
@@ -118,6 +122,8 @@ class TESS_API TessResultRenderer {
    * will produce .hocr files.
    */
   TessResultRenderer(const char* outputbase, const char* extension);
+  
+  TessResultRenderer(const char* extension);
 
   // Hook for specialized handling in BeginDocument()
   virtual bool BeginDocumentHandler();
@@ -147,6 +153,8 @@ class TESS_API TessResultRenderer {
   FILE* fout_;                // output file pointer
   TessResultRenderer* next_;  // Can link multiple renderers together
   bool happy_;                // I get grumpy when the disk fills up, etc.
+  bool writeToBuffer_;
+  std::vector<char> outputBuffer_;
 };
 
 /**
@@ -217,6 +225,11 @@ class TESS_API TessPDFRenderer : public TessResultRenderer {
   TessPDFRenderer(const char* outputbase, const char* datadir,
                   bool textonly = false);
 
+ TessPDFRenderer(const char* datadir, bool textonly = false);
+    
+    
+ std::vector<char> getOutputBuffer();
+    
  protected:
   bool BeginDocumentHandler() override;
   bool AddImageHandler(TessBaseAPI* api) override;
@@ -232,6 +245,8 @@ class TESS_API TessPDFRenderer : public TessResultRenderer {
   GenericVector<long int> offsets_;  // offset of every PDF object in bytes
   GenericVector<long int> pages_;    // object number for every /Page object
   std::string datadir_;              // where to find the custom font
+  std::vector<char> outputBuffer_;
+  bool writeToBuffer_;
   bool textonly_;                    // skip images if set
   // Bookkeeping only. DIY = Do It Yourself.
   void AppendPDFObjectDIY(size_t objectsize);


### PR DESCRIPTION
We need to be able to render the OCR PDFs to a data buffer instead of a file, to support encryption of PDFs.

Please, someone with C/C++ knowledge, take a closer look and make some suggestions.